### PR TITLE
Improve scanning concurrency with Go port scanner

### DIFF
--- a/Ingram/config.py
+++ b/Ingram/config.py
@@ -21,6 +21,10 @@ _config = {
     'vulnerable': 'results.csv',
     'snapshots': 'snapshots',
 
+    # go port scanner
+    'go_bin': None,
+    'go_workers': 100,
+
     # wechat
     'wxuid': '',
     'wxtoken': '',

--- a/Ingram/core.py
+++ b/Ingram/core.py
@@ -12,6 +12,7 @@ from .utils import color
 from .utils import common
 from .utils import fingerprint
 from .utils import port_scan
+from .utils.port_scan import go_port_scan
 from .utils import status_bar
 from .utils import timer
 
@@ -67,27 +68,33 @@ class Core:
 
         # 存活检测 (是否有必要)
 
-        # 端口扫描
-        for port in ports:
-            if port_scan(ip, port, self.config.timeout):
-                logger.info(f"{ip} port {port} is open")
-                # 指纹
-                if product := fingerprint(ip, port, self.config):
-                    logger.info(f"{ip}:{port} is {product}")
-                    verified = False
-                    # poc verify & exploit
-                    for poc in self.poc_dict[product]:
-                        if results := poc.verify(ip, port):
-                            verified = True
-                            # found 加 1
-                            self.data.add_found()
-                            # 将验证成功的 poc 记录到 config.vulnerable 中
-                            self.data.add_vulnerable(results[:6])
-                            # snapshot
-                            if not self.config.disable_snapshot:
-                                self.snapshot_pipeline.put((poc.exploit, results))
-                    if not verified:
-                        self.data.add_not_vulnerable([ip, str(port), product])
+        open_ports = []
+        if self.config.go_bin:
+            open_ports = go_port_scan(ip, ports, self.config.go_bin, self.config.timeout)
+        else:
+            for port in ports:
+                if port_scan(ip, port, self.config.timeout):
+                    open_ports.append(port)
+
+        for port in open_ports:
+            logger.info(f"{ip} port {port} is open")
+            # 指纹
+            if product := fingerprint(ip, port, self.config):
+                logger.info(f"{ip}:{port} is {product}")
+                verified = False
+                # poc verify & exploit
+                for poc in self.poc_dict[product]:
+                    if results := poc.verify(ip, port):
+                        verified = True
+                        # found 加 1
+                        self.data.add_found()
+                        # 将验证成功的 poc 记录到 config.vulnerable 中
+                        self.data.add_vulnerable(results[:6])
+                        # snapshot
+                        if not self.config.disable_snapshot:
+                            self.snapshot_pipeline.put((poc.exploit, results))
+                if not verified:
+                    self.data.add_not_vulnerable([ip, str(port), product])
         self.data.add_done()
         self.data.record_running_state()
 

--- a/Ingram/utils/argparse.py
+++ b/Ingram/utils/argparse.py
@@ -10,6 +10,8 @@ def get_parse():
     parser.add_argument('-t', '--th_num', type=int, default=150, help='the processes num')
     parser.add_argument('-T', '--timeout', type=int, default=3, help='requests timeout')
     parser.add_argument('-D', '--disable_snapshot', action='store_true', help='disable snapshot')
+    parser.add_argument('--go-bin', type=str, default=None, help='path to go port scanner binary')
+    parser.add_argument('--go-workers', type=int, default=100, help='concurrency of go port scanner')
     parser.add_argument('--debug', action='store_true', help='log all msg')
 
     args = parser.parse_args()

--- a/Ingram/utils/port_scan.py
+++ b/Ingram/utils/port_scan.py
@@ -1,10 +1,12 @@
-"""端口扫描"""
+"""端口扫描工具"""
 import socket
+import subprocess
+from typing import Iterable, List
 
 from loguru import logger
 
 
-def port_scan(ip: str, port: str, timeout: int=1) -> bool:
+def port_scan(ip: str, port: str, timeout: int = 1) -> bool:
     """使用 socket 的方式"""
     s = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
     s.settimeout(timeout)
@@ -16,3 +18,28 @@ def port_scan(ip: str, port: str, timeout: int=1) -> bool:
     finally:
         s.close()
     return False
+
+
+def go_port_scan(ip: str, ports: Iterable[str], go_bin: str, timeout: int = 1) -> List[int]:
+    """使用 Go 程序一次性扫描多个端口
+
+    params:
+    - ip: ip 地址
+    - ports: 端口列表
+    - go_bin: Go 可执行文件路径
+    - timeout: 超时时间（秒）
+    """
+    cmd = [go_bin, "-timeout", str(timeout), ip] + list(map(str, ports))
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        open_ports = []
+        for line in res.stdout.splitlines():
+            if ':' in line:
+                try:
+                    open_ports.append(int(line.split(":")[1]))
+                except ValueError:
+                    continue
+        return open_ports
+    except Exception as e:
+        logger.error(e)
+        return []

--- a/README.en.md
+++ b/README.en.md
@@ -107,15 +107,27 @@ optional arguments:
 
 ## Port scanner
 
-+ We can use powerful port scanner to obtain active hosts, thereby reducing the scanning range of Ingram and improving the running speed. The specific method is to organize the result file of the port scanner into the format of `ip:port` and use it as the input file of Ingram
+The project ships with a lightweight Go based port scanner `goscan` which can quickly detect open ports concurrently.
 
-+ Here is a brief demonstration of masscan as an example (the detailed usage of masscan will not be repeated here).
+**Build** it in the project root:
 
-+ First, use masscan to scan the surviving host on port 80 or 8000-8008 (you sure can change the port anything else if you want): `masscan -p80,8000-8008 -iL INPUT -oL OUTPUT --rate 8000`
+```bash
+go build -o go_port_scan ./goscan
+```
 
-+ After masscan is done, sort out the result file: `grep 'open' OUTPUT | awk '{printf"%s:%s\n", $4, $3}' > input`
+Run Ingram with `--go-bin` to use the Go scanner:
 
-+ Then: `python run_ingram.py -i input -o output`
+```bash
+python3 run_ingram.py -i input -o output --go-bin ./go_port_scan
+```
+
+You can still use masscan to pre-scan hosts if needed:
+
+```bash
+masscan -p80,8000-8008 -iL INPUT -oL OUTPUT --rate 8000
+grep 'open' OUTPUT | awk '{printf"%s:%s\n", $4, $3}' > input
+python3 run_ingram.py -i input -o output
+```
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -112,13 +112,27 @@ optional arguments:
 
 ## 端口扫描器
 
-+ 我们可以利用强大的端口扫描器来获取活动主机，进而缩小 Ingram 的扫描范围，提高运行速度，具体做法是将端口扫描器的结果文件整理成 `ip:port` 的格式，并作为 Ingram 的输入
+项目中新增了一个基于 Go 的简单端口扫描器 `goscan`，可在高并发下快速发现开放端口。
 
-+ 这里以 masscan 为例简单演示一下（masscan 的详细用法这里不再赘述），首先用 masscan 扫描 80 或 8000-8008 端口存活的主机：`masscan -p80,8000-8008 -iL 目标文件 -oL 结果文件 --rate 8000`
+**编译**：在项目根目录执行
 
-+ masscan 运行完之后，将结果文件整理一下：`grep 'open' 结果文件 | awk '{printf"%s:%s\n", $4, $3}' > targets.txt`
+```bash
+go build -o go_port_scan ./goscan
+```
 
-+ 之后对这些主机进行扫描：`python run_ingram.py -i targets.txt -o out`
+编译后运行 Ingram 时通过 `--go-bin` 指定该可执行文件路径即可让 Go 程序负责端口扫描：
+
+```bash
+python3 run_ingram.py -i targets.txt -o out --go-bin ./go_port_scan
+```
+
+你也可以继续使用 masscan 等外部工具来提前获取开放端口，方式如下：
+
+```bash
+masscan -p80,8000-8008 -iL 目标文件 -oL 结果文件 --rate 8000
+grep 'open' 结果文件 | awk '{printf"%s:%s\n", $4, $3}' > targets.txt
+python3 run_ingram.py -i targets.txt -o out
+```
 
 
 ## ~~微信提醒~~(已移除)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module ingram
+
+go 1.24.3

--- a/goscan/main.go
+++ b/goscan/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+func main() {
+	timeout := flag.Int("timeout", 1, "timeout in seconds")
+	concurrency := flag.Int("c", 100, "concurrency")
+	flag.Parse()
+	args := flag.Args()
+	if len(args) < 2 {
+		fmt.Println("Usage: go_port_scan [options] ip port1 port2 ...")
+		return
+	}
+	ip := args[0]
+	ports := args[1:]
+
+	portCh := make(chan string, len(ports))
+	resultCh := make(chan string, len(ports))
+	var wg sync.WaitGroup
+
+	for i := 0; i < *concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for port := range portCh {
+				conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), time.Duration(*timeout)*time.Second)
+				if err == nil {
+					conn.Close()
+					resultCh <- port
+				}
+			}
+		}()
+	}
+
+	for _, p := range ports {
+		portCh <- p
+	}
+	close(portCh)
+
+	wg.Wait()
+	close(resultCh)
+	for p := range resultCh {
+		fmt.Printf("%s:%s\n", ip, p)
+	}
+}


### PR DESCRIPTION
## Summary
- implement lightweight Go port scanner in `goscan`
- add `--go-bin` and `--go-workers` CLI flags
- integrate Go scanner into core scanning workflow
- document Go scanner usage in README (English & Chinese)
- include Go module files

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `gofmt -w goscan/main.go`
- `go build -o go_port_scan ./goscan` *(build successful, binary removed)*

------
https://chatgpt.com/codex/tasks/task_e_687a3c6919bc8327b7c4b139b68dc102