### PR TITLE
Improve fingerprint error handling

### DIFF
--- a/Ingram/utils/fingerprint.py
+++ b/Ingram/utils/fingerprint.py
@@ -14,24 +14,35 @@ def _parse(req, rule_val):
     def check_one(item):
         left, right = re.search(r'(.*)=`(.*)`', item).groups()
 
-        if left == 'md5':
-            if hashlib.md5(req.content).hexdigest() == right:
-                return True
-        elif left == 'title':
-            html = etree.HTML(req.text)
-            if right.lower() in html.xpath('//title')[0].xpath('string(.)').lower():
-                return True
-        elif left == 'body':
-            html = etree.HTML(req.text)
-            for node in html.xpath('//body')[0]:
-                if right.lower() in node.xpath('string(.)').lower():
-                    return True
-        elif left == 'headers':
-            for header_item in req.headers.items():
-                if right.lower() in ''.join(header_item).lower():
-                    return True
-        elif left == 'status_code':
-            return int(req.status_code) == int(right)
+        try:
+            if left == 'md5':
+                return hashlib.md5(req.content).hexdigest() == right
+
+            if left == 'title':
+                html = etree.HTML(req.text)
+                if html is not None:
+                    titles = html.xpath('//title')
+                    if titles and right.lower() in titles[0].xpath('string(.)').lower():
+                        return True
+
+            elif left == 'body':
+                html = etree.HTML(req.text)
+                if html is not None:
+                    bodies = html.xpath('//body')
+                    for node in bodies[0] if bodies else []:
+                        if right.lower() in node.xpath('string(.)').lower():
+                            return True
+
+            elif left == 'headers':
+                for header_item in req.headers.items():
+                    if right.lower() in ''.join(header_item).lower():
+                        return True
+
+            elif left == 'status_code':
+                return int(req.status_code) == int(right)
+        except Exception as e:
+            logger.error(e)
+
         return False
 
     return all(map(check_one, rule_val.split('&&')))


### PR DESCRIPTION
## Summary
- make `_parse` more resilient to missing tags or parsing errors

## Testing
- `python3 -m py_compile Ingram/utils/fingerprint.py`
- `python3 -m py_compile run_ingram.py Ingram/core.py Ingram/utils/fingerprint.py`

------
https://chatgpt.com/codex/tasks/task_e_6884acc585b48327b2866008f1ee70bd