### PR TITLE
Improve fingerprint resilience

### DIFF
--- a/Ingram/core.py
+++ b/Ingram/core.py
@@ -68,7 +68,14 @@ class Core:
                 logger.info(f"{ip} port {port} closed")
                 continue
             logger.info(f"{ip} port {port} is open")
-            if product := fingerprint(ip, port, self.config):
+            try:
+                product = fingerprint(ip, port, self.config)
+            except Exception as e:
+                logger.error(e)
+                # fingerprint 阶段报错，直接跳过当前目标
+                continue
+
+            if product:
                 logger.info(f"{ip}:{port} is {product}")
                 verified = False
                 for poc in self.poc_dict[product]:

--- a/Ingram/utils/fingerprint.py
+++ b/Ingram/utils/fingerprint.py
@@ -14,24 +14,35 @@ def _parse(req, rule_val):
     def check_one(item):
         left, right = re.search(r'(.*)=`(.*)`', item).groups()
 
-        if left == 'md5':
-            if hashlib.md5(req.content).hexdigest() == right:
-                return True
-        elif left == 'title':
-            html = etree.HTML(req.text)
-            if right.lower() in html.xpath('//title')[0].xpath('string(.)').lower():
-                return True
-        elif left == 'body':
-            html = etree.HTML(req.text)
-            for node in html.xpath('//body')[0]:
-                if right.lower() in node.xpath('string(.)').lower():
-                    return True
-        elif left == 'headers':
-            for header_item in req.headers.items():
-                if right.lower() in ''.join(header_item).lower():
-                    return True
-        elif left == 'status_code':
-            return int(req.status_code) == int(right)
+        try:
+            if left == 'md5':
+                return hashlib.md5(req.content).hexdigest() == right
+
+            if left == 'title':
+                html = etree.HTML(req.text)
+                if html is not None:
+                    titles = html.xpath('//title')
+                    if titles and right.lower() in titles[0].xpath('string(.)').lower():
+                        return True
+
+            elif left == 'body':
+                html = etree.HTML(req.text)
+                if html is not None:
+                    bodies = html.xpath('//body')
+                    for node in bodies[0] if bodies else []:
+                        if right.lower() in node.xpath('string(.)').lower():
+                            return True
+
+            elif left == 'headers':
+                for header_item in req.headers.items():
+                    if right.lower() in ''.join(header_item).lower():
+                        return True
+
+            elif left == 'status_code':
+                return int(req.status_code) == int(right)
+        except Exception as e:
+            logger.error(e)
+
         return False
 
     return all(map(check_one, rule_val.split('&&')))
@@ -41,9 +52,14 @@ def fingerprint(ip, port, config):
     req_dict = {}  # 暂存 requests 的返回值
     session = requests.session()
     headers = {'Connection': 'close', 'User-Agent': config.user_agent}
+
     for rule in config.rules:
         try:
-            req = req_dict.get(rule.path) or session.get(f"http://{ip}:{port}{rule.path}", headers=headers, timeout=config.timeout)
+            req = req_dict.get(rule.path) or session.get(
+                f"http://{ip}:{port}{rule.path}",
+                headers=headers,
+                timeout=config.timeout,
+            )
             # req_dict 里只保存 status_code 为 200 的 req
             if (rule.path not in req_dict) and (req.status_code == 200):
                 req_dict[rule.path] = req
@@ -52,4 +68,6 @@ def fingerprint(ip, port, config):
                 return rule.product
         except Exception as e:
             logger.error(e)
+            # 出现异常直接跳过当前目标
+            return None
     return None


### PR DESCRIPTION
## Summary
- return early from `fingerprint` when any exception occurs
- skip target in `Core._scan` if `fingerprint` errors

## Testing
- `python3 -m py_compile Ingram/utils/fingerprint.py`
- `python3 -m py_compile run_ingram.py Ingram/core.py Ingram/utils/fingerprint.py`


------
https://chatgpt.com/codex/tasks/task_e_6884acc585b48327b2866008f1ee70bd